### PR TITLE
Replace error message concatenation with template string

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -48,7 +48,7 @@ export default class SafeEventEmitter extends EventEmitter {
         throw er; // Unhandled 'error' event
       }
       // At least give some kind of context to the user
-      const err = new Error('Unhandled error.' + (er ? ' (' + er.message + ')' : ''));
+      const err = new Error(`Unhandled error.${er ? ` (${er.message})` : ''}`);
       (err as any).context = er;
       throw err; // Unhandled 'error' event
     }


### PR DESCRIPTION
Refs #1, where this was a comment.

This PR updates the way we're constructing the error message to use a template string instead of a string concatenation.