### PR TITLE
Update README with publishing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@ ee.emit('boom'); // No error here
 
 // Error is thrown after setTimeout
 ```
+
+### Release & Publishing
+
+The project follows the same release process as the other libraries in the MetaMask organization:
+
+1. Create a release branch
+    - For a typical release, this would be based on `master`
+    - To update an older maintained major version, base the release branch on the major version branch (e.g. `1.x`)
+2. Update the changelog
+3. Update version in package.json file (e.g. `yarn version --minor --no-git-tag-version`)
+4. Create a pull request targeting the base branch (e.g. master or 1.x)
+5. Code review and QA
+6. Once approved, the PR is squashed & merged
+7. The commit on the base branch is tagged
+8. The tag can be published as needed


### PR DESCRIPTION
Refs #5

This PR adds publishing instructions to the bottom of the README, similar to the rest of the organization's libraries.