### PR TITLE
Fix links in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Migrate to TypeScript ([#1](https://github.com/MetaMask/safe-event-emitter/pull/1))
 
-[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v2.0.0...HEAD
-[2.0.0]:https://github.com/MetaMask/eslint-config/tree/v2.0.0
+[Unreleased]:https://github.com/MetaMask/safe-event-emitter/compare/v2.0.0...HEAD
+[2.0.0]:https://github.com/MetaMask/safe-event-emitter/tree/v2.0.0


### PR DESCRIPTION
This PR fixes the links in the CHANGELOG which were pointing to the incorrect repo.