### PR TITLE
Add Dependabot config

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,12 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "development"
+    versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
This change adds a GitHub Dependabot configuration to enable daily checks for dependency updates.

[See the docs for more information.][1]

This config enables checking for updates to the dev dependencies (`allow[0].dependency-type`) in the root `package.json` file (`directory`) every weekday (`schedule.interval`) and increasing the version range (if necessary, `versioning-strategy`). As I understand it, this would see minor and patch updates not touch the `package.json` file while major versions will include a change to the `package.json` file.

This ignores production dependencies as there are none, currently, _and_ because Dependabot doesn't support multiple update based on `allow[].dependency-type`.

  [1]:https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates

Refs https://github.com/MetaMask/metamask-module-template/issues/14