### PR TITLE
fix esm path on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.0",
   "description": "An EventEmitter that isolates the emitter from errors in handlers",
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.mjs",
   "types": "dist/cjs/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
The module path defined on package.json does not match with the exports and the artifacts. This change's not tested but current release of `a68ac06` is emitting an error on some builds.