### PR TITLE
Drop support for Node.js <18

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/MetaMask/safe-event-emitter.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": "^18.18 || >=20"
   },
   "scripts": {
     "prepublishOnly": "yarn build",


### PR DESCRIPTION
Node.js <18 is no longer supported. This is also required for #144.