### PR TITLE
Remove support for Node.js versions 12-15,17,19,21

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/MetaMask/safe-event-emitter.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": "^16.20 || ^18.16 || >=20"
   },
   "scripts": {
     "prepublishOnly": "yarn build",


### PR DESCRIPTION
Increasing minimum Node.js to at least 16 support wold enable automated publishing using MetaMask actions. There are still a few dependents on this package maintaining Node.js v16 support, therefore this doesn't go all the way to 18 like #145.